### PR TITLE
Target uploads to new dropbox address

### DIFF
--- a/build_selections.sh
+++ b/build_selections.sh
@@ -362,11 +362,17 @@ find $DIR -not -name README -maxdepth 1 -mindepth 1 | \
 # UPLOAD to wp1.kiwix.org                                            #
 ######################################################################
 
-echo "Upload $DIR to download.kiwix.org"
-scp -o StrictHostKeyChecking=no -r $DIR $(cat $SCRIPT_DIR/remote)
-REMOTE_DIR=$(sed s/.*:// < $SCRIPT_DIR/remote)$(basename $DIR);
+remote=$(cat $SCRIPT_DIR/remote)
+if echo $remote | grep "::" > /dev/null ; then
+    port="22"
+else
+    port=$(echo $remote | cut -d ":" -f 2)
+fi
+echo "Upload $DIR to $remote on port $port"
 find $DIR -name "customs.zip" -o -name "tops.zip" -o -name "projects.zip" | \
-    $PARALLEL "ssh -o StrictHostKeyChecking=no \$(sed s/:.*// < $SCRIPT_DIR/remote) unzip -o $REMOTE_DIR/\$(basename {}) -d $REMOTE_DIR"
+    $PARALLEL "unzip -o -d $DIR {}"
+scp -P $port -o StrictHostKeyChecking=no -r $DIR $host
+
 
 ######################################################################
 # CLEAN DIRECTORY                                                    #


### PR DESCRIPTION
SSH server which was used to receive file uploads (CI, nightly and release) has been migrated to a new one on a different address.
Username, Key and paths are unchanged.
Most notable changes are the use of master.download.kiwix.org as the target in replacement of mirror.download.kiwix.org (although it would still work) and the port to which SSH is listening on (30022 instead of 22)

I changed the expected `remote` file format: must include a port number (or `::`).

I already changed remote file on instance-wp1.mwoffliner to `ci@download.openzim.org:30022:/data/openzim/wp1/`

You'll notice I changed the logic a bit so that top/customs/projects ZIP files are extracted on disk first then uploaded.

Reason behind this is that there is no shell on that server so you can't unzip on the remote anymore.
I've looked at files and I don't think file size is an issue in that case.

**Note**: we can do it differently; it's just a suggestion so that your builds are fixed (those are probably failing starting tonight).