### PR TITLE
Move to new linktarget table

### DIFF
--- a/build_selections.sh
+++ b/build_selections.sh
@@ -194,7 +194,7 @@ do
     UPPER_LIMIT=$((UPPER_LIMIT + 10000))
     echo "   from pl_from from $LOWER_LIMIT to $UPPER_LIMIT..."
     $MYSQL \
-        "SELECT pl_from, pl_title FROM pagelinks WHERE pl_namespace = 0 AND pl_from_namespace = 0 AND pl_from >= $LOWER_LIMIT AND pl_from < $UPPER_LIMIT" \
+        "SELECT pl_from, lt_title AS pl_title FROM pagelinks LEFT JOIN linktarget ON pl_target_id = lt_id WHERE lt_namespace = 0 AND pl_from_namespace = 0 AND pl_from >= $LOWER_LIMIT AND pl_from < $UPPER_LIMIT" \
         -N -h ${DB_HOST} ${DB} >> $PAGELINKS
     NEW_SIZE=$(ls -la $PAGELINKS 2> /dev/null | cut -d " " -f5)
 done


### PR DESCRIPTION
Fix #48 

Since Mediawiki 1.38, page links targets are stored in a new `linktarget` table instead of the original `pagelinks` table.

Details:
- https://www.mediawiki.org/wiki/Manual:Linktarget_table
- https://www.mediawiki.org/wiki/Manual:Pagelinks_table

This commit modifies the query on pagelinks to retrieve link target title from the new table instead of the former one.

This is a bit quick and dirty because this is not supposed to be used in the long term since this tool is supposed to be decommissioned / replaced by a Python alternative.